### PR TITLE
[FEAT] 대기열 진입

### DIFF
--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/SkalaMiniProject1Application.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/SkalaMiniProject1Application.java
@@ -2,9 +2,11 @@ package com.example.SKALA_Mini_Project_1;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import io.github.cdimascio.dotenv.Dotenv;
 
+@EnableScheduling
 @SpringBootApplication
 public class SkalaMiniProject1Application {
 

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/domain/Waiting/controller/QueueController.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/domain/Waiting/controller/QueueController.java
@@ -1,0 +1,65 @@
+package com.example.SKALA_Mini_Project_1.domain.Waiting.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.Map;
+
+
+import com.example.SKALA_Mini_Project_1.domain.Waiting.service.QueueService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/queue")
+public class QueueController {
+    private final QueueService queueService;
+
+    @PostMapping("/enter")
+    public ResponseEntity<?> enter(
+            @RequestParam Long concertId,
+            @RequestParam String userId,
+            @RequestParam long fandomWeightMillis) {
+
+        long rank = queueService.enterQueue(concertId, userId, fandomWeightMillis);
+
+        return ResponseEntity.ok(Map.of(
+                "rank", rank
+        ));
+    }
+
+    @GetMapping("/rank")
+    public ResponseEntity<?> rank(
+            @RequestParam Long concertId,
+            @RequestParam String userId) {
+
+        long rank = queueService.getRank(concertId, userId);
+
+        return ResponseEntity.ok(Map.of(
+                "rank", rank
+        ));
+    }
+
+    @GetMapping("/can-enter")
+        public ResponseEntity<?> canEnter(
+                @RequestParam Long concertId,
+                @RequestParam String userId) {
+
+        boolean allowed = queueService.canEnter(concertId, userId);
+
+        if (allowed) {
+                return ResponseEntity.ok(Map.of(
+                        "allowed", true,
+                        "redirectUrl", "http://localhost:8081/seats?concertId=" + concertId
+                ));
+        }
+
+        return ResponseEntity.ok(Map.of(
+                "allowed", false
+        ));
+        }
+}

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/domain/Waiting/dto/QueueEnterRequest.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/domain/Waiting/dto/QueueEnterRequest.java
@@ -1,0 +1,12 @@
+package com.example.SKALA_Mini_Project_1.domain.Waiting.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class QueueEnterRequest {
+    private Long concertId;
+    private String userId;
+    private Long fandomWeightMillis;
+}

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/domain/Waiting/dto/QueueStatusResponse.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/domain/Waiting/dto/QueueStatusResponse.java
@@ -1,0 +1,12 @@
+package com.example.SKALA_Mini_Project_1.domain.Waiting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class QueueStatusResponse {
+    private long rank;
+    private boolean allowed;
+    private String redirectUrl;
+}

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/domain/Waiting/service/QueueScheduler.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/domain/Waiting/service/QueueScheduler.java
@@ -1,0 +1,34 @@
+package com.example.SKALA_Mini_Project_1.domain.Waiting.service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import java.time.Duration;
+
+
+@Component
+@RequiredArgsConstructor
+public class QueueScheduler {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Scheduled(fixedDelay = 3000)
+public void openEntrance() {
+
+    Boolean locked = redisTemplate.opsForValue()
+        .setIfAbsent("queue:scheduler:lock", "1", Duration.ofSeconds(2));
+
+    if (!Boolean.TRUE.equals(locked)) {
+        return; // 다른 서버가 실행 중이면 그냥 종료
+    }
+
+    String enterKey = "queue:concert:1:enter";
+
+    String current = redisTemplate.opsForValue().get(enterKey);
+
+    long allowed = current == null ? 0 : Long.parseLong(current);
+
+    allowed += 100;
+
+    redisTemplate.opsForValue().set(enterKey, String.valueOf(allowed));
+}
+}

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/domain/Waiting/service/QueueService.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/domain/Waiting/service/QueueService.java
@@ -1,0 +1,87 @@
+package com.example.SKALA_Mini_Project_1.domain.Waiting.service;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import java.util.concurrent.ThreadLocalRandom;
+import java.time.Duration;
+
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class QueueService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // 팬덤 가중치 최대치 (밀리초)
+    private static final int MAX_WEIGHT_MILLIS = 5000;
+
+    public long enterQueue(Long concertId, String userId, long fandomWeightMillis) {
+
+        String key = getQueueKey(concertId);
+
+        // 현재 시간 기반 점수 계산
+        long now = System.currentTimeMillis();
+        long weight = Math.min(fandomWeightMillis, MAX_WEIGHT_MILLIS);
+        long jitter = ThreadLocalRandom.current().nextLong(0, 50);
+
+        // 팬덤 가중치와 무작위 지터를 반영한 점수 계산
+        long score = now - weight + jitter;
+
+        redisTemplate.opsForZSet()
+                .add(key, userId, score);
+
+        Long rank = redisTemplate.opsForZSet()
+                .rank(key, userId);
+
+        return rank != null ? rank : -1;
+    }
+
+    // 현재 대기열에서의 순위 조회
+    public long getRank(Long concertId, String userId) {
+        String key = getQueueKey(concertId);
+        Long rank = redisTemplate.opsForZSet().rank(key, userId);
+        return rank != null ? rank : -1;
+    }
+
+    public boolean canEnter(Long concertId, String userId) {
+
+        String queueKey = getQueueKey(concertId);
+        String enterKey = getEnterKey(concertId);
+
+        Long rank = redisTemplate.opsForZSet().rank(queueKey, userId);
+        String allowedStr = redisTemplate.opsForValue().get(enterKey);
+
+        if (rank == null || allowedStr == null) return false;
+
+        long allowed = Long.parseLong(allowedStr);
+
+        if (rank < allowed) {
+
+            // 입장 토큰 발급 (30초)
+            String tokenKey = getTokenKey(concertId, userId);
+
+            redisTemplate.opsForValue()
+                    .set(tokenKey, "1", Duration.ofSeconds(30));
+
+            // 선택: 대기열에서 제거
+            redisTemplate.opsForZSet().remove(queueKey, userId);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private String getTokenKey(Long concertId, String userId) {
+        return "queue:enter:token:" + concertId + ":" + userId;
+    }
+
+    private String getQueueKey(Long concertId) {
+        return "queue:concert:" + concertId;
+    }
+
+    private String getEnterKey(Long concertId) {
+        return "queue:concert:" + concertId + ":enter";
+    }
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -8,3 +8,29 @@ services:
     ports:
       - "6379:6379"
     command: redis-server --appendonly yes
+
+  postgres:
+    image: postgres:17
+    container_name: concert-postgres
+    environment:
+      POSTGRES_USER: skala
+      POSTGRES_PASSWORD: skala1229
+      POSTGRES_DB: concert
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  nginx:
+    image: nginx:latest
+    container_name: concert-nginx
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./infra/nginx/nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - redis
+      - postgres
+
+volumes:
+  postgres-data:

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,0 +1,20 @@
+events {}
+
+http {
+
+    upstream seat_servers {
+        least_conn;
+
+        server host.docker.internal:11010;
+        server host.docker.internal:11011;
+        server host.docker.internal:11012;
+    }
+
+    server {
+        listen 8080;
+
+        location / {
+            proxy_pass http://seat_servers;
+        }
+    }
+}


### PR DESCRIPTION
대기열 진입 시 Redis key:value 생성 구현

## 📌 관련 기능
<!-- 아래 중 하나 선택 후 나머지는 지워주세요 -->
- [ ] 소셜 기능
- [ ] 좌석 선택
- [x] 대기열
- [ ] 결제
- [ ] 기타 (작성)

---

## 🔗 관련 이슈
<!-- 연결된 이슈 번호 작성 (예: #12) -->
Closes #23 

---

## 📝 작업 내용
<!-- 무엇을 구현/수정했는지 간단히 작성 -->

- 콘서트 대기열 진입 구현
- 팬 점수에 따른 가중치 조정 구현

---

## 💻 작업 범위
<!-- 해당되는 항목 체크 -->
- [ ] Front (Vue)
- [x] Back (Spring)
- [x] Infra

---

## ✅ 테스트 확인 (선택)
<!-- 확인한 항목 체크 -->

- [ ] 정상 동작 확인
- [ ] 콘솔 에러 없음
- [ ] API 응답 정상
- [ ] 예외 케이스 테스트

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, API 명세 변경 사항, DB 변경 사항 등 -->
