### PR TITLE
[Feat] 프론트 user api 연결 및 페이지 

### DIFF
--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/global/config/SecurityConfig.java
@@ -1,14 +1,21 @@
 package com.example.SKALA_Mini_Project_1.global.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import com.example.SKALA_Mini_Project_1.global.jwt.JwtAuthenticationFilter;
 
@@ -29,6 +36,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+            .cors(Customizer.withDefaults())
             .csrf(csrf -> csrf.disable())  // REST API이므로 CSRF 비활성화
             .sessionManagement(session -> 
                 session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)  // JWT 사용으로 세션 미사용
@@ -55,5 +63,34 @@ public class SecurityConfig {
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of(
+                "http://localhost:5173",
+                "http://127.0.0.1:5173",
+                "http://localhost:5174",
+                "http://127.0.0.1:5174",
+                "http://localhost:4173",
+                "http://127.0.0.1:4173"
+        ));
+        configuration.setAllowedMethods(List.of(
+                HttpMethod.GET.name(),
+                HttpMethod.POST.name(),
+                HttpMethod.PUT.name(),
+                HttpMethod.PATCH.name(),
+                HttpMethod.DELETE.name(),
+                HttpMethod.OPTIONS.name()
+        ));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Authorization"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,5 +3,6 @@
 ## Getting Started
 
 1. Install dependencies: `npm install`
-2. Start dev server: `npm run dev`
-3. Build for production: `npm run build`
+2. (Optional) Set backend proxy target: `VITE_API_PROXY_TARGET=http://localhost:8080` (or `:8081`)
+3. Start dev server: `npm run dev`
+4. Build for production: `npm run build`

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,6 +3,6 @@
 ## Getting Started
 
 1. Install dependencies: `npm install`
-2. (Optional) Set backend proxy target: `VITE_API_PROXY_TARGET=http://localhost:8080` (or `:8081`)
+2. (Optional) Set backend proxy target (default: `http://localhost:8080`): `VITE_API_PROXY_TARGET=http://localhost:8081`
 3. Start dev server: `npm run dev`
 4. Build for production: `npm run build`

--- a/frontend/src/components/BookingConfirmation.vue
+++ b/frontend/src/components/BookingConfirmation.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { Check, Home, QrCode, Smartphone } from 'lucide-vue-next';
 import { computed } from 'vue';
-import type { BookingData, Step } from '../types';
+import type { BookingData } from '../types';
 
 const props = defineProps<{
   bookingData: BookingData;
 }>();
 
 const emit = defineEmits<{
-  navigate: [step: Step];
+  navigate: [path: string];
 }>();
 
 const totalAmount = computed(() => props.bookingData.seats.reduce((sum, seat) => sum + seat.price, 0));
@@ -65,14 +65,14 @@ const totalAmount = computed(() => props.bookingData.seats.reduce((sum, seat) =>
     <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
       <button
         class="flex items-center justify-center space-x-2 rounded-sm border border-[#FF6B00] py-3 font-bold text-[#FF6B00] transition-colors hover:bg-orange-50 md:py-4"
-        @click="emit('navigate', 'mypage')"
+        @click="emit('navigate', '/mypage')"
       >
         <QrCode :size="20" />
         <span>모바일 티켓 확인</span>
       </button>
       <button
         class="flex items-center justify-center space-x-2 rounded-sm bg-[#333] py-3 font-bold text-white transition-colors hover:bg-black md:py-4"
-        @click="emit('navigate', 'detail')"
+        @click="emit('navigate', '/concert/detail')"
       >
         <Home :size="20" />
         <span>메인으로 돌아가기</span>

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -1,36 +1,39 @@
 <script setup lang="ts">
 import { Menu, Search, User } from 'lucide-vue-next';
-import type { Step } from '../types';
 
-defineProps<{
-  currentStep: Step;
+const props = defineProps<{
+  currentPath: string;
+  isAuthenticated: boolean;
 }>();
 
 const emit = defineEmits<{
-  navigate: [step: Step];
+  navigate: [path: string];
+  logout: [];
 }>();
 
-const steps: Array<{ id: Step; label: string }> = [
-  { id: 'detail', label: '공연상세' },
-  { id: 'queue', label: '대기열' },
-  { id: 'seat', label: '좌석선택' },
-  { id: 'payment', label: '결제하기' },
-  { id: 'confirm', label: '예매확인' },
-  { id: 'mypage', label: '마이페이지' }
+const navItems: Array<{ path: string; label: string }> = [
+  { path: '/concert/detail', label: '공연상세' },
+  { path: '/concert/queue', label: '대기열' },
+  { path: '/concert/seat', label: '좌석선택' },
+  { path: '/concert/payment', label: '결제하기' },
+  { path: '/concert/confirm', label: '예매확인' },
+  { path: '/mypage', label: '마이페이지' }
 ];
+
+const isActive = (path: string) => props.currentPath.startsWith(path);
 </script>
 
 <template>
   <header class="sticky top-0 z-50 w-full border-b border-[#e0e0e0] bg-white">
     <div class="hidden border-b border-[#e0e0e0] bg-[#f8f8f8] py-1 md:block">
       <div class="mx-auto flex max-w-[1200px] justify-end space-x-4 px-4 text-xs text-[#666]">
-        <button class="hover:underline">로그인</button>
-        <span class="text-[#ddd]">|</span>
-        <button class="hover:underline">회원가입</button>
+        <button v-if="!isAuthenticated" class="hover:underline" @click="emit('navigate', '/login')">로그인</button>
+        <button v-if="!isAuthenticated" class="hover:underline" @click="emit('navigate', '/signup')">회원가입</button>
+        <button v-if="isAuthenticated" class="hover:underline" @click="emit('logout')">로그아웃</button>
         <span class="text-[#ddd]">|</span>
         <button class="hover:underline">고객센터</button>
         <span class="text-[#ddd]">|</span>
-        <button class="hover:underline" @click="emit('navigate', 'mypage')">마이페이지</button>
+        <button class="hover:underline" @click="emit('navigate', '/mypage')">마이페이지</button>
       </div>
     </div>
 
@@ -38,9 +41,9 @@ const steps: Array<{ id: Step; label: string }> = [
       <div class="flex items-center space-x-3 md:space-x-8">
         <button
           class="flex items-center text-xl font-bold tracking-tighter text-[#FF6B00] md:text-2xl"
-          @click="emit('navigate', 'detail')"
+          @click="emit('navigate', '/concert/detail')"
         >
-          <span class="mr-1">🎫</span> 티켓코리아
+          <span class="mr-1">🎫</span> FairLine Ticket
         </button>
 
         <div class="relative hidden md:block">
@@ -56,7 +59,10 @@ const steps: Array<{ id: Step; label: string }> = [
       </div>
 
       <div class="flex items-center space-x-3 md:space-x-4">
-        <button class="hidden items-center space-x-1 rounded-sm border border-[#ddd] px-3 py-1.5 text-sm hover:bg-gray-50 md:flex">
+        <button
+          class="hidden items-center space-x-1 rounded-sm border border-[#ddd] px-3 py-1.5 text-sm hover:bg-gray-50 md:flex"
+          @click="emit('navigate', '/mypage')"
+        >
           <User :size="16" />
           <span>나의 예매</span>
         </button>
@@ -70,17 +76,17 @@ const steps: Array<{ id: Step; label: string }> = [
       <div class="mx-auto max-w-[1200px] px-4">
         <nav class="flex space-x-1 overflow-x-auto whitespace-nowrap">
           <button
-            v-for="step in steps"
-            :key="step.id"
+            v-for="item in navItems"
+            :key="item.path"
             class="border-b-2 px-6 py-3 text-sm font-bold transition-colors"
             :class="
-              currentStep === step.id
+              isActive(item.path)
                 ? 'border-[#FF6B00] text-[#FF6B00]'
                 : 'border-transparent text-[#333] hover:text-[#FF6B00]'
             "
-            @click="emit('navigate', step.id)"
+            @click="emit('navigate', item.path)"
           >
-            {{ step.label }}
+            {{ item.label }}
           </button>
         </nav>
       </div>

--- a/frontend/src/components/LoginPage.vue
+++ b/frontend/src/components/LoginPage.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { apiRequest, ApiError } from '../services/api';
+import { setAuthUser, setToken } from '../services/auth';
+
+interface LoginResponse {
+  userId: number;
+  email: string;
+  name: string;
+  message: string;
+  accessToken: string;
+}
+
+const emit = defineEmits<{
+  navigate: [path: string];
+  loggedIn: [];
+}>();
+
+const email = ref('');
+const password = ref('');
+const loading = ref(false);
+const errorMessage = ref('');
+
+const submit = async () => {
+  if (loading.value) {
+    return;
+  }
+
+  errorMessage.value = '';
+  loading.value = true;
+
+  try {
+    const response = await apiRequest<LoginResponse>('/api/users/login', {
+      method: 'POST',
+      body: JSON.stringify({
+        email: email.value,
+        password: password.value
+      })
+    });
+
+    setToken(response.accessToken);
+    setAuthUser({
+      userId: response.userId,
+      email: response.email,
+      name: response.name
+    });
+
+    emit('loggedIn');
+    emit('navigate', '/mypage');
+  } catch (error) {
+    errorMessage.value = error instanceof ApiError ? error.message : '로그인 중 오류가 발생했습니다.';
+  } finally {
+    loading.value = false;
+  }
+};
+</script>
+
+<template>
+  <div class="mx-auto max-w-[460px] px-4 py-10 md:py-14">
+    <h2 class="mb-6 border-b-2 border-[#333] pb-2 text-2xl font-bold text-[#333]">로그인</h2>
+
+    <form class="space-y-4" @submit.prevent="submit">
+      <div>
+        <label class="mb-1 block text-sm font-bold text-[#444]">이메일</label>
+        <input
+          v-model="email"
+          type="email"
+          required
+          autocomplete="email"
+          class="h-11 w-full rounded-sm border border-[#ddd] px-3 outline-none focus:border-[#FF6B00]"
+          placeholder="user@example.com"
+        />
+      </div>
+
+      <div>
+        <label class="mb-1 block text-sm font-bold text-[#444]">비밀번호</label>
+        <input
+          v-model="password"
+          type="password"
+          required
+          autocomplete="current-password"
+          class="h-11 w-full rounded-sm border border-[#ddd] px-3 outline-none focus:border-[#FF6B00]"
+          placeholder="비밀번호를 입력하세요"
+        />
+      </div>
+
+      <p v-if="errorMessage" class="text-sm font-semibold text-red-500">{{ errorMessage }}</p>
+
+      <button
+        type="submit"
+        :disabled="loading"
+        class="h-11 w-full rounded-sm bg-[#FF6B00] text-sm font-bold text-white disabled:opacity-60"
+      >
+        {{ loading ? '로그인 중...' : '로그인' }}
+      </button>
+
+      <button
+        type="button"
+        class="h-11 w-full rounded-sm border border-[#ddd] text-sm font-bold text-[#666]"
+        @click="emit('navigate', '/signup')"
+      >
+        회원가입
+      </button>
+    </form>
+  </div>
+</template>

--- a/frontend/src/components/SignupPage.vue
+++ b/frontend/src/components/SignupPage.vue
@@ -1,0 +1,370 @@
+<script setup lang="ts">
+import { computed, onUnmounted, ref } from 'vue'
+import { apiRequest, ApiError } from '../services/api'
+
+interface EmailVerificationResponse {
+  email: string
+  message: string
+  expirationMinutes: number | null
+  resendAvailableAt: number | null
+}
+
+interface SignUpResponse {
+  userId: number
+  email: string
+  name: string
+  phone: string | null
+  createdAt: string
+  message: string
+}
+
+const emit = defineEmits<{
+  navigate: [path: string]
+}>()
+
+const email = ref('')
+const code = ref('')
+const password = ref('')
+const passwordConfirm = ref('')
+const name = ref('')
+const phone = ref('')
+
+const emailSent = ref(false)
+const emailVerified = ref(false)
+const codeExpiresInSeconds = ref(0)
+const resendCooldownSeconds = ref(0)
+const loading = ref(false)
+const infoMessage = ref('')
+const errorMessage = ref('')
+
+let countdownTimer: ReturnType<typeof setInterval> | null = null
+let resendTimer: ReturnType<typeof setInterval> | null = null
+
+const passwordMismatch = computed(
+  () => passwordConfirm.value.length > 0 && password.value !== passwordConfirm.value,
+)
+
+const codeTimerText = computed(() => {
+  const minutes = Math.floor(codeExpiresInSeconds.value / 60)
+  const seconds = codeExpiresInSeconds.value % 60
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+})
+
+const resendTimerText = computed(() => `${resendCooldownSeconds.value}초`)
+
+const isCodeExpired = computed(
+  () => emailSent.value && !emailVerified.value && codeExpiresInSeconds.value <= 0,
+)
+
+const canSubmitSignup = computed(
+  () =>
+    emailVerified.value &&
+    password.value.length >= 8 &&
+    passwordConfirm.value.length > 0 &&
+    !passwordMismatch.value &&
+    name.value.length > 0,
+)
+
+const stopCountdown = () => {
+  if (countdownTimer) {
+    clearInterval(countdownTimer)
+    countdownTimer = null
+  }
+}
+
+const stopResendCooldown = () => {
+  if (resendTimer) {
+    clearInterval(resendTimer)
+    resendTimer = null
+  }
+}
+
+const startResendCooldown = (seconds: number) => {
+  resendCooldownSeconds.value = Math.max(0, seconds)
+  stopResendCooldown()
+
+  if (resendCooldownSeconds.value <= 0) {
+    return
+  }
+
+  resendTimer = setInterval(() => {
+    if (resendCooldownSeconds.value <= 1) {
+      resendCooldownSeconds.value = 0
+      stopResendCooldown()
+      return
+    }
+    resendCooldownSeconds.value -= 1
+  }, 1000)
+}
+
+const parseRetryAfterSeconds = (message: string): number | null => {
+  const matched = message.match(/(\d+)\s*초/)
+  if (!matched) {
+    return null
+  }
+  const value = Number(matched[1])
+  return Number.isNaN(value) ? null : value
+}
+
+const getSecondsFromUnixTimestamp = (unixTimestamp: number): number => {
+  const nowInSeconds = Math.floor(Date.now() / 1000)
+  return Math.max(0, unixTimestamp - nowInSeconds)
+}
+
+const startCountdown = (expirationMinutes: number | null) => {
+  const duration = expirationMinutes ?? 5
+  codeExpiresInSeconds.value = duration * 60
+  stopCountdown()
+
+  countdownTimer = setInterval(() => {
+    if (codeExpiresInSeconds.value <= 1) {
+      codeExpiresInSeconds.value = 0
+      stopCountdown()
+      return
+    }
+    codeExpiresInSeconds.value -= 1
+  }, 1000)
+}
+
+const withLoading = async (callback: () => Promise<void>) => {
+  if (loading.value) {
+    return
+  }
+
+  loading.value = true
+  errorMessage.value = ''
+
+  try {
+    await callback()
+  } catch (error) {
+    errorMessage.value =
+      error instanceof ApiError ? error.message : '요청 처리 중 오류가 발생했습니다.'
+  } finally {
+    loading.value = false
+  }
+}
+
+const sendCode = async () => {
+  if (resendCooldownSeconds.value > 0) {
+    errorMessage.value = `인증 코드는 1분에 한 번만 발송할 수 있습니다. ${resendCooldownSeconds.value}초 후 재시도해주세요.`
+    return
+  }
+
+  if (loading.value) {
+    return
+  }
+
+  loading.value = true
+  errorMessage.value = ''
+
+  try {
+    const response = await apiRequest<EmailVerificationResponse>('/api/users/email/send', {
+      method: 'POST',
+      body: JSON.stringify({ email: email.value }),
+    })
+
+    emailSent.value = true
+    emailVerified.value = false
+    code.value = ''
+    startCountdown(response.expirationMinutes)
+    startResendCooldown(
+      response.resendAvailableAt ? getSecondsFromUnixTimestamp(response.resendAvailableAt) : 60,
+    )
+    infoMessage.value = response.message
+  } catch (error) {
+    if (error instanceof ApiError) {
+      const seconds = parseRetryAfterSeconds(error.message)
+      if (seconds && seconds > 0) {
+        startResendCooldown(seconds)
+        errorMessage.value = `인증 코드는 1분에 한 번만 발송할 수 있습니다. ${seconds}초 후 재시도해주세요.`
+      } else {
+        errorMessage.value = error.message
+      }
+    } else {
+      errorMessage.value = '요청 처리 중 오류가 발생했습니다.'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+const verifyCode = async () => {
+  if (isCodeExpired.value) {
+    errorMessage.value = '인증 코드 유효시간이 만료되었습니다. 인증코드를 다시 발송해주세요.'
+    return
+  }
+
+  await withLoading(async () => {
+    const response = await apiRequest<EmailVerificationResponse>('/api/users/email/verify', {
+      method: 'POST',
+      body: JSON.stringify({ email: email.value, code: code.value }),
+    })
+
+    emailVerified.value = true
+    stopCountdown()
+    infoMessage.value = response.message
+  })
+}
+
+const signup = async () => {
+  if (!canSubmitSignup.value) {
+    return
+  }
+
+  await withLoading(async () => {
+    const response = await apiRequest<SignUpResponse>('/api/users/signup', {
+      method: 'POST',
+      body: JSON.stringify({
+        email: email.value,
+        password: password.value,
+        name: name.value,
+        phone: phone.value || null,
+      }),
+    })
+
+    infoMessage.value = response.message
+    emit('navigate', '/login')
+  })
+}
+
+onUnmounted(() => {
+  stopCountdown()
+  stopResendCooldown()
+})
+</script>
+
+<template>
+  <div class="mx-auto max-w-[520px] px-4 py-10 md:py-14">
+    <h2 class="mb-6 border-b-2 border-[#333] pb-2 text-2xl font-bold text-[#333]">회원가입</h2>
+
+    <form class="space-y-4" @submit.prevent="signup">
+      <div>
+        <label class="mb-1 block text-sm font-bold text-[#444]">이메일</label>
+        <div class="flex gap-2">
+          <input
+            v-model="email"
+            type="email"
+            required
+            autocomplete="email"
+            class="h-11 flex-1 rounded-sm border border-[#ddd] px-3 outline-none focus:border-[#FF6B00]"
+            placeholder="user@example.com"
+          />
+          <button
+            type="button"
+            :disabled="loading || resendCooldownSeconds > 0"
+            class="h-11 min-w-[110px] rounded-sm border border-[#FF6B00] px-3 text-sm font-bold text-[#FF6B00] disabled:opacity-60"
+            @click="sendCode"
+          >
+            {{ resendCooldownSeconds > 0 ? `재발송 ${resendTimerText}` : '인증코드 발송' }}
+          </button>
+        </div>
+        <p v-if="resendCooldownSeconds > 0" class="mt-1 text-xs font-semibold text-[#666]">
+          인증 코드는 1분에 한 번만 발송할 수 있습니다. {{ resendTimerText }} 후 재시도해주세요.
+        </p>
+      </div>
+
+      <div>
+        <label class="mb-1 block text-sm font-bold text-[#444]">인증코드</label>
+        <div class="flex gap-2">
+          <input
+            v-model="code"
+            type="text"
+            maxlength="6"
+            :disabled="!emailSent"
+            class="h-11 flex-1 rounded-sm border border-[#ddd] px-3 outline-none focus:border-[#FF6B00] disabled:bg-[#f5f5f5]"
+            placeholder="6자리 숫자"
+          />
+          <button
+            type="button"
+            :disabled="loading || !emailSent"
+            class="h-11 min-w-[110px] rounded-sm border border-[#333] px-3 text-sm font-bold text-[#333] disabled:opacity-60"
+            @click="verifyCode"
+          >
+            인증 확인
+          </button>
+        </div>
+        <p
+          v-if="emailSent && !emailVerified && !isCodeExpired"
+          class="mt-1 text-xs font-semibold text-[#666]"
+        >
+          인증코드 유효시간 {{ codeTimerText }}
+        </p>
+        <p v-if="isCodeExpired" class="mt-1 text-xs font-semibold text-red-500">
+          인증코드 유효시간이 만료되었습니다. 다시 발송해주세요.
+        </p>
+        <p v-if="emailVerified" class="mt-1 text-xs font-semibold text-green-600">
+          이메일 인증이 완료되었습니다.
+        </p>
+      </div>
+
+      <div>
+        <label class="mb-1 block text-sm font-bold text-[#444]">비밀번호</label>
+        <input
+          v-model="password"
+          type="password"
+          required
+          minlength="8"
+          autocomplete="new-password"
+          class="h-11 w-full rounded-sm border border-[#ddd] px-3 outline-none focus:border-[#FF6B00]"
+          placeholder="8자 이상의 비밀번호를 입력하세요"
+        />
+      </div>
+
+      <div>
+        <label class="mb-1 block text-sm font-bold text-[#444]">비밀번호 확인</label>
+        <input
+          v-model="passwordConfirm"
+          type="password"
+          required
+          minlength="8"
+          autocomplete="new-password"
+          class="h-11 w-full rounded-sm border border-[#ddd] px-3 outline-none focus:border-[#FF6B00]"
+          placeholder="비밀번호를 다시 입력하세요"
+        />
+        <p v-if="passwordMismatch" class="mt-1 text-xs font-semibold text-red-500">
+          비밀번호가 일치하지 않습니다.
+        </p>
+      </div>
+
+      <div>
+        <label class="mb-1 block text-sm font-bold text-[#444]">이름</label>
+        <input
+          v-model="name"
+          type="text"
+          required
+          class="h-11 w-full rounded-sm border border-[#ddd] px-3 outline-none focus:border-[#FF6B00]"
+          placeholder="이름을 입력하세요"
+        />
+      </div>
+
+      <div>
+        <label class="mb-1 block text-sm font-bold text-[#444]">전화번호 (선택)</label>
+        <input
+          v-model="phone"
+          type="text"
+          class="h-11 w-full rounded-sm border border-[#ddd] px-3 outline-none focus:border-[#FF6B00]"
+          placeholder="010-1234-5678"
+        />
+      </div>
+
+      <p v-if="infoMessage" class="text-sm font-semibold text-green-600">{{ infoMessage }}</p>
+      <p v-if="errorMessage" class="text-sm font-semibold text-red-500">{{ errorMessage }}</p>
+
+      <button
+        type="submit"
+        :disabled="loading || !canSubmitSignup"
+        class="h-11 w-full rounded-sm bg-[#FF6B00] text-sm font-bold text-white disabled:opacity-60"
+      >
+        {{ loading ? '처리 중...' : '회원가입 완료' }}
+      </button>
+
+      <button
+        type="button"
+        class="h-11 w-full rounded-sm border border-[#ddd] text-sm font-bold text-[#666]"
+        @click="emit('navigate', '/login')"
+      >
+        로그인으로 이동
+      </button>
+    </form>
+  </div>
+</template>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,48 @@
+export class ApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+
+interface RequestOptions extends RequestInit {
+  token?: string;
+}
+
+export async function apiRequest<T>(path: string, options: RequestOptions = {}): Promise<T> {
+  const { token, headers, ...rest } = options;
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...rest,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...headers
+    }
+  });
+
+  const text = await response.text();
+  let data: unknown = null;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = null;
+    }
+  }
+
+  if (!response.ok) {
+    const message =
+      (data && typeof data === 'object' && 'message' in data && typeof data.message === 'string'
+        ? data.message
+        : null) ?? `요청 실패 (${response.status})`;
+    throw new ApiError(message, response.status);
+  }
+
+  return data as T;
+}

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,51 @@
+export interface AuthUser {
+  userId: number;
+  email: string;
+  name: string;
+}
+
+const TOKEN_KEY = 'ticketkorea_access_token';
+const USER_KEY = 'ticketkorea_user';
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+export function getAuthUser(): AuthUser | null {
+  const raw = localStorage.getItem(USER_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as AuthUser;
+  } catch {
+    localStorage.removeItem(USER_KEY);
+    return null;
+  }
+}
+
+export function setAuthUser(user: AuthUser): void {
+  localStorage.setItem(USER_KEY, JSON.stringify(user));
+}
+
+export function clearAuthUser(): void {
+  localStorage.removeItem(USER_KEY);
+}
+
+export function isLoggedIn(): boolean {
+  return Boolean(getToken());
+}
+
+export function clearAuth(): void {
+  clearToken();
+  clearAuthUser();
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,16 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
+const proxyTarget = process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:8081';
+
 export default defineConfig({
-  plugins: [vue()]
+  plugins: [vue()],
+  server: {
+    proxy: {
+      '/api': {
+        target: proxyTarget,
+        changeOrigin: true
+      }
+    }
+  }
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
-const proxyTarget = process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:8081';
+const proxyTarget = process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:8080';
 
 export default defineConfig({
   plugins: [vue()],


### PR DESCRIPTION
## 📌 관련 기능
<!-- 아래 중 하나 선택 후 나머지는 지워주세요 -->
- [x] 소셜 기능
- [ ] 좌석 선택
- [ ] 대기열
- [ ] 결제
- [ ] 기타 (작성)

---

## 🔗 관련 이슈
<!-- 연결된 이슈 번호 작성 (예: #12) -->
Closes #32 

---

## 📝 작업 내용
<!-- 무엇을 구현/수정했는지 간단히 작성 -->
1. user 인증 흐름 프론트 연동 및 페이지 분리
2. 회원가입 ux (이메일 인증코드 유효시간 5분 카운트다운, 인증코드 재발송 1분 제한 카운트다운, 비밀번호 불일치 검증 추가
3. Backend CORS 허용 오리진 추가, 로딩 경로 보강(./backend/.env, ./.env 순서) <- 저는 에러 안 나고 잘 돌아갔는데 확인 부탁드려욥!!!
4. Vite 프록시 설정 추가
기본 타깃: http://localhost:8080
필요 시 VITE_API_PROXY_TARGET로 오버라이드 가능 (저는 8081 포트이기 때문에 아마 저한테만 해당하는 내용일 거에요)

---

## 💻 작업 범위
<!-- 해당되는 항목 체크 -->
- [x] Front (Vue)
- [x] Back (Spring)
- [ ] Infra

---

## ✅ 테스트 확인 (선택)
<!-- 확인한 항목 체크 -->

- [x] 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] API 응답 정상
- [ ] 예외 케이스 테스트

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, API 명세 변경 사항, DB 변경 사항 등 -->
