### PR TITLE
[FEAT] 좌석 일괄 선점 기능 구현

### DIFF
--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/dto/BatchSeatHoldRequest.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/dto/BatchSeatHoldRequest.java
@@ -1,0 +1,29 @@
+package com.example.SKALA_Mini_Project_1.modules.seats.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "좌석 일괄 선점 요청 DTO")
+public class BatchSeatHoldRequest {
+
+    @NotNull(message = "콘서트 ID는 필수입니다.")
+    @Schema(description = "콘서트 ID", example = "1")
+    private Long concertId;
+
+    @NotEmpty(message = "좌석 ID 목록은 비어 있을 수 없습니다.")
+    @Size(max = 4, message = "좌석은 최대 4매까지만 선택할 수 있습니다.")
+    @ArraySchema(
+            schema = @Schema(description = "선점할 좌석 ID", example = "401"),
+            arraySchema = @Schema(description = "선점할 좌석 ID 목록(최대 4개)")
+    )
+    private List<Long> seatIds;
+}

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/dto/SeatSelectRequest.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/dto/SeatSelectRequest.java
@@ -19,21 +19,21 @@ public class SeatSelectRequest {
     private Long concertId;
 
     @NotNull(message = "좌석 ID는 필수입니다.")
-    @Schema(description = "좌석 PK ID (section/rowNumber/seatNumber와 동일 좌석이어야 함)", example = "2")
+    @Schema(description = "좌석 PK ID (section/rowNumber/seatNumber와 동일 좌석이어야 함)", example = "401")
     private Long seatId;
 
     @NotBlank(message = "구역은 필수입니다.")
-    @Schema(description = "좌석 구역 코드", example = "A")
+    @Schema(description = "좌석 구역 코드", example = "B")
     private String section;
 
     @NotNull(message = "열 정보는 필수입니다.")
     @Positive(message = "열은 1 이상이어야 합니다.")
-    @Schema(description = "열 번호(1 이상)", example = "1")
+    @Schema(description = "열 번호(1 이상)", example = "6")
     private Integer rowNumber;
 
     @NotNull(message = "좌석 번호는 필수입니다.")
     @Positive(message = "좌석 번호는 1 이상이어야 합니다.")
-    @Schema(description = "좌석 번호(1 이상)", example = "2")
+    @Schema(description = "좌석 번호(1 이상)", example = "1")
     private Integer seatNumber;
 
     public SeatSelectRequest(Long concertId, Long seatId, String section, Integer rowNumber, Integer seatNumber) {

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/repository/SeatRepository.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/repository/SeatRepository.java
@@ -1,5 +1,6 @@
 package com.example.SKALA_Mini_Project_1.modules.seats.repository;
 
+import java.util.Optional;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +23,16 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
             nativeQuery = true
     )
     List<Object[]> findSeatMapByConcertId(Long concertId);
+
+    @Query(
+            value = """
+                    SELECT s.*
+                    FROM seats s
+                    JOIN schedules sc ON sc.id = s.schedule_id
+                    WHERE s.id = :seatId
+                      AND sc.concert_id = :concertId
+                    """,
+            nativeQuery = true
+    )
+    Optional<Seat> findByIdAndConcertId(Long seatId, Long concertId);
 }


### PR DESCRIPTION
## 📌 관련 기능
<!-- 아래 중 하나 선택 후 나머지는 지워주세요 -->
- [ ] 소셜 기능
- [x] 좌석 선택
- [ ] 대기열
- [ ] 결제
- [ ] 기타 (작성)

---

## 🔗 관련 이슈
<!-- 연결된 이슈 번호 작성 (예: #12) -->
Closes #35 

---

## 📝 작업 내용
- 좌석 일괄 선점 API 구현

---

## 💻 작업 범위
<!-- 해당되는 항목 체크 -->
- [ ] Front (Vue)
- [x] Back (Spring)
- [ ] Infra

---

## ✅ 테스트 확인 (선택)
<!-- 확인한 항목 체크 -->

- [x] 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] API 응답 정상
- [x] 예외 케이스 테스트

---

## 📎 참고 사항 (선택)
`POST /api/seats/holds`
