### PR TITLE
[FEAT] 좌석 선점 취소 API 구현

### DIFF
--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/global/redis/RedisKeyGenerator.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/global/redis/RedisKeyGenerator.java
@@ -5,10 +5,7 @@ public class RedisKeyGenerator {
         return "queue:concert:" + concertId;
     }
 
-    public static String seatLockKey(Long concertId, String section, Integer rowNumber, Integer seatNumber) {
-        return "seat:concert:" + concertId
-                + ":section:" + section
-                + ":row:" + rowNumber
-                + ":seat:" + seatNumber;
+    public static String seatLockKey(Long concertId, Long seatId) {
+        return "seat:concert:" + concertId + ":seatId:" + seatId;
     }
 }

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/global/redis/RedisLockRepository.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/global/redis/RedisLockRepository.java
@@ -14,9 +14,8 @@ import lombok.RequiredArgsConstructor;
 public class RedisLockRepository {
     private final RedisTemplate<String, String> redisTemplate;
 
-    public boolean lockSeat(Long concertId, String section, Integer rowNumber, Integer seatNumber, String userId) {
-
-        String key = RedisKeyGenerator.seatLockKey(concertId, section, rowNumber, seatNumber);
+    public boolean lockSeat(Long concertId, Long seatId, String userId) {
+        String key = RedisKeyGenerator.seatLockKey(concertId, seatId);
 
         Boolean success = redisTemplate.opsForValue()
                 .setIfAbsent(key, userId, Duration.ofMinutes(5));
@@ -24,22 +23,20 @@ public class RedisLockRepository {
         return Boolean.TRUE.equals(success);
     }
 
-    public void unlockSeat(Long concertId, String section, Integer rowNumber, Integer seatNumber) {
-
-        String key = RedisKeyGenerator.seatLockKey(concertId, section, rowNumber, seatNumber);
+    public void unlockSeat(Long concertId, Long seatId) {
+        String key = RedisKeyGenerator.seatLockKey(concertId, seatId);
 
         redisTemplate.delete(key);
     }
 
-    public String getSeatOwner(Long concertId, String section, Integer rowNumber, Integer seatNumber) {
-
-        String key = RedisKeyGenerator.seatLockKey(concertId, section, rowNumber, seatNumber);
+    public String getSeatOwner(Long concertId, Long seatId) {
+        String key = RedisKeyGenerator.seatLockKey(concertId, seatId);
 
         return redisTemplate.opsForValue().get(key);
     }
 
-    public Long getSeatLockTtlSeconds(Long concertId, String section, Integer rowNumber, Integer seatNumber) {
-        String key = RedisKeyGenerator.seatLockKey(concertId, section, rowNumber, seatNumber);
+    public Long getSeatLockTtlSeconds(Long concertId, Long seatId) {
+        String key = RedisKeyGenerator.seatLockKey(concertId, seatId);
         Long ttl = redisTemplate.getExpire(key, TimeUnit.SECONDS);
         if (ttl == null || ttl <= 0) {
             return null;

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/controller/SeatController.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/controller/SeatController.java
@@ -53,9 +53,6 @@ public class SeatController {
             SeatReservationService.SeatHoldResult result = seatReservationService.reserveSeatTemporary(
                     requestDto.getConcertId(),
                     requestDto.getSeatId(),
-                    requestDto.getSection(),
-                    requestDto.getRowNumber(),
-                    requestDto.getSeatNumber(),
                     userId
             );
 
@@ -169,9 +166,6 @@ public class SeatController {
             SeatReservationService.SeatReleaseResult result = seatReservationService.releaseSeatHold(
                     requestDto.getConcertId(),
                     requestDto.getSeatId(),
-                    requestDto.getSection(),
-                    requestDto.getRowNumber(),
-                    requestDto.getSeatNumber(),
                     userId
             );
 

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/dto/BatchSeatHoldRequest.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/dto/BatchSeatHoldRequest.java
@@ -1,0 +1,29 @@
+package com.example.SKALA_Mini_Project_1.modules.seats.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "좌석 일괄 선점 요청 DTO")
+public class BatchSeatHoldRequest {
+
+    @NotNull(message = "콘서트 ID는 필수입니다.")
+    @Schema(description = "콘서트 ID", example = "1")
+    private Long concertId;
+
+    @NotEmpty(message = "좌석 ID 목록은 비어 있을 수 없습니다.")
+    @Size(max = 4, message = "좌석은 최대 4매까지만 선택할 수 있습니다.")
+    @ArraySchema(
+            schema = @Schema(description = "선점할 좌석 ID", example = "401"),
+            arraySchema = @Schema(description = "선점할 좌석 ID 목록(최대 4개)")
+    )
+    private List<Long> seatIds;
+}

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/dto/SeatSelectRequest.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/dto/SeatSelectRequest.java
@@ -19,21 +19,21 @@ public class SeatSelectRequest {
     private Long concertId;
 
     @NotNull(message = "좌석 ID는 필수입니다.")
-    @Schema(description = "좌석 PK ID (section/rowNumber/seatNumber와 동일 좌석이어야 함)", example = "2")
+    @Schema(description = "좌석 PK ID (section/rowNumber/seatNumber와 동일 좌석이어야 함)", example = "401")
     private Long seatId;
 
     @NotBlank(message = "구역은 필수입니다.")
-    @Schema(description = "좌석 구역 코드", example = "A")
+    @Schema(description = "좌석 구역 코드", example = "B")
     private String section;
 
     @NotNull(message = "열 정보는 필수입니다.")
     @Positive(message = "열은 1 이상이어야 합니다.")
-    @Schema(description = "열 번호(1 이상)", example = "1")
+    @Schema(description = "열 번호(1 이상)", example = "6")
     private Integer rowNumber;
 
     @NotNull(message = "좌석 번호는 필수입니다.")
     @Positive(message = "좌석 번호는 1 이상이어야 합니다.")
-    @Schema(description = "좌석 번호(1 이상)", example = "2")
+    @Schema(description = "좌석 번호(1 이상)", example = "1")
     private Integer seatNumber;
 
     public SeatSelectRequest(Long concertId, Long seatId, String section, Integer rowNumber, Integer seatNumber) {

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/dto/SeatSelectRequest.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/dto/SeatSelectRequest.java
@@ -1,16 +1,14 @@
 package com.example.SKALA_Mini_Project_1.modules.seats.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 @Schema(
-        description = "좌석 선점/해제 요청 DTO. 동일 사용자가 이미 선점한 좌석을 다시 요청하면 선점 해제됩니다."
+        description = "좌석 선점/해제 요청 DTO"
 )
 public class SeatSelectRequest {
 
@@ -19,28 +17,11 @@ public class SeatSelectRequest {
     private Long concertId;
 
     @NotNull(message = "좌석 ID는 필수입니다.")
-    @Schema(description = "좌석 PK ID (section/rowNumber/seatNumber와 동일 좌석이어야 함)", example = "401")
+    @Schema(description = "좌석 PK ID", example = "401")
     private Long seatId;
 
-    @NotBlank(message = "구역은 필수입니다.")
-    @Schema(description = "좌석 구역 코드", example = "B")
-    private String section;
-
-    @NotNull(message = "열 정보는 필수입니다.")
-    @Positive(message = "열은 1 이상이어야 합니다.")
-    @Schema(description = "열 번호(1 이상)", example = "6")
-    private Integer rowNumber;
-
-    @NotNull(message = "좌석 번호는 필수입니다.")
-    @Positive(message = "좌석 번호는 1 이상이어야 합니다.")
-    @Schema(description = "좌석 번호(1 이상)", example = "1")
-    private Integer seatNumber;
-
-    public SeatSelectRequest(Long concertId, Long seatId, String section, Integer rowNumber, Integer seatNumber) {
+    public SeatSelectRequest(Long concertId, Long seatId) {
         this.concertId = concertId;
         this.seatId = seatId;
-        this.section = section;
-        this.rowNumber = rowNumber;
-        this.seatNumber = seatNumber;
     }
 }

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/repository/SeatRepository.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/repository/SeatRepository.java
@@ -1,5 +1,6 @@
 package com.example.SKALA_Mini_Project_1.modules.seats.repository;
 
+import java.util.Optional;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +23,16 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
             nativeQuery = true
     )
     List<Object[]> findSeatMapByConcertId(Long concertId);
+
+    @Query(
+            value = """
+                    SELECT s.*
+                    FROM seats s
+                    JOIN schedules sc ON sc.id = s.schedule_id
+                    WHERE s.id = :seatId
+                      AND sc.concert_id = :concertId
+                    """,
+            nativeQuery = true
+    )
+    Optional<Seat> findByIdAndConcertId(Long seatId, Long concertId);
 }

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/service/SeatMapService.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/service/SeatMapService.java
@@ -43,8 +43,8 @@ public class SeatMapService {
         BigDecimal price = (BigDecimal) row[6];
 
         // Redis에 캐싱된 사용자 정보를 가져옴
-        String owner = redisLockRepository.getSeatOwner(concertId, section, rowNumber, seatNumber);
-        Long ttlSeconds = redisLockRepository.getSeatLockTtlSeconds(concertId, section, rowNumber, seatNumber);
+        String owner = redisLockRepository.getSeatOwner(concertId, seatId);
+        Long ttlSeconds = redisLockRepository.getSeatLockTtlSeconds(concertId, seatId);
 
         Boolean isHeldByMe = null;
         OffsetDateTime holdExpiresAt = null;

--- a/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/service/SeatReservationService.java
+++ b/backend/src/main/java/com/example/SKALA_Mini_Project_1/modules/seats/service/SeatReservationService.java
@@ -45,32 +45,26 @@ public class SeatReservationService {
     public SeatHoldResult reserveSeatTemporary(
             Long concertId,
             Long seatId,
-            String section,
-            Integer rowNumber,
-            Integer seatNumber,
             Long userId
     ) {
-        Seat seat = validateSeat(concertId, seatId, section, rowNumber, seatNumber);
+        Seat seat = validateSeat(concertId, seatId);
         if (seat.getStatus() == SeatStatus.RESERVED) {
             throw new IllegalStateException("이미 판매된 좌석입니다.");
         }
 
         String userIdString = String.valueOf(userId);
-        String currentOwner = redisLockRepository.getSeatOwner(concertId, section, rowNumber, seatNumber);
+        String currentOwner = redisLockRepository.getSeatOwner(concertId, seatId);
 
         if (Objects.equals(currentOwner, userIdString)) {
-            redisLockRepository.unlockSeat(concertId, section, rowNumber, seatNumber);
+            redisLockRepository.unlockSeat(concertId, seatId);
             log.info("좌석 {} 선점 해제 성공 (사용자: {})", seatId, userId);
             return SeatHoldResult.RELEASED;
         }
 
         if (currentOwner != null) {
             log.info(
-                    "좌석 {} - {}-{}-{} 선점 실패: 현재 소유자(userId: {}), 시도자(userId: {})",
-                    concertId,
-                    section,
-                    rowNumber,
-                    seatNumber,
+                    "좌석 {} 선점 실패: 현재 소유자(userId: {}), 시도자(userId: {})",
+                    seatId,
                     currentOwner,
                     userId
             );
@@ -83,22 +77,19 @@ public class SeatReservationService {
         }
 
         // Redis를 통한 선점 시도 (HOLD는 Redis TTL로만 관리)
-        boolean isLocked = redisLockRepository.lockSeat(concertId, section, rowNumber, seatNumber, userIdString);
+        boolean isLocked = redisLockRepository.lockSeat(concertId, seatId, userIdString);
         
         if (!isLocked) {
-            String lockOwner = redisLockRepository.getSeatOwner(concertId, section, rowNumber, seatNumber);
+            String lockOwner = redisLockRepository.getSeatOwner(concertId, seatId);
             if (Objects.equals(lockOwner, userIdString)) {
-                redisLockRepository.unlockSeat(concertId, section, rowNumber, seatNumber);
+                redisLockRepository.unlockSeat(concertId, seatId);
                 log.info("좌석 {} 선점 해제 성공 (사용자: {})", seatId, userId);
                 return SeatHoldResult.RELEASED;
             }
 
             log.info(
-                    "좌석 {} - {}-{}-{} 선점 실패: 현재 소유자(userId: {}), 시도자(userId: {})",
-                    concertId,
-                    section,
-                    rowNumber,
-                    seatNumber,
+                    "좌석 {} 선점 실패: 현재 소유자(userId: {}), 시도자(userId: {})",
+                    seatId,
                     lockOwner,
                     userId
             );
@@ -136,7 +127,7 @@ public class SeatReservationService {
                 continue;
             }
 
-            String owner = redisLockRepository.getSeatOwner(concertId, seat.getSection(), seat.getRowNumber(), seat.getSeatNumber());
+            String owner = redisLockRepository.getSeatOwner(concertId, seat.getId());
             if (owner == null) {
                 seatsToLock.add(seat);
                 continue;
@@ -161,9 +152,7 @@ public class SeatReservationService {
         for (Seat seat : seatsToLock) {
             boolean locked = redisLockRepository.lockSeat(
                     concertId,
-                    seat.getSection(),
-                    seat.getRowNumber(),
-                    seat.getSeatNumber(),
+                    seat.getId(),
                     userIdString
             );
 
@@ -175,9 +164,7 @@ public class SeatReservationService {
                     if (lockedSeat != null) {
                         redisLockRepository.unlockSeat(
                                 concertId,
-                                lockedSeat.getSection(),
-                                lockedSeat.getRowNumber(),
-                                lockedSeat.getSeatNumber()
+                                lockedSeat.getId()
                         );
                     }
                 }
@@ -195,14 +182,11 @@ public class SeatReservationService {
     public SeatReleaseResult releaseSeatHold(
             Long concertId,
             Long seatId,
-            String section,
-            Integer rowNumber,
-            Integer seatNumber,
             Long userId
     ) {
-        validateSeat(concertId, seatId, section, rowNumber, seatNumber);
+        validateSeat(concertId, seatId);
 
-        String owner = redisLockRepository.getSeatOwner(concertId, section, rowNumber, seatNumber);
+        String owner = redisLockRepository.getSeatOwner(concertId, seatId);
         if (owner == null) {
             return SeatReleaseResult.ALREADY_RELEASED;
         }
@@ -211,26 +195,12 @@ public class SeatReservationService {
             throw new IllegalStateException("다른 사용자가 선점한 좌석은 해제할 수 없습니다.");
         }
 
-        redisLockRepository.unlockSeat(concertId, section, rowNumber, seatNumber);
+        redisLockRepository.unlockSeat(concertId, seatId);
         return SeatReleaseResult.RELEASED;
     }
 
-    private Seat validateSeat(
-            Long concertId,
-            Long seatId,
-            String section,
-            Integer rowNumber,
-            Integer seatNumber
-    ) {
-        Seat seat = seatRepository.findByIdAndConcertId(seatId, concertId)
+    private Seat validateSeat(Long concertId, Long seatId) {
+        return seatRepository.findByIdAndConcertId(seatId, concertId)
                 .orElseThrow(() -> new EntityNotFoundException("좌석이 존재하지 않습니다. ID: " + seatId));
-
-        if (!Objects.equals(seat.getSection(), section)
-                || !Objects.equals(seat.getRowNumber(), rowNumber)
-                || !Objects.equals(seat.getSeatNumber(), seatNumber)) {
-            throw new IllegalArgumentException("요청한 좌석 정보가 seatId와 일치하지 않습니다.");
-        }
-
-        return seat;
     }
 }


### PR DESCRIPTION
## 📌 관련 기능
<!-- 아래 중 하나 선택 후 나머지는 지워주세요 -->
- [ ] 소셜 기능
- [x] 좌석 선택
- [ ] 대기열
- [ ] 결제
- [ ] 기타 (작성)

---

## 🔗 관련 이슈
<!-- 연결된 이슈 번호 작성 (예: #12) -->
Closes #36 

---

## 📝 작업 내용
- 사용자가 좌석 선점 또는 결제 과정 중 Timeout 또는 예매 취소 시, 좌석 취소를 위한 API 구현

---

## 💻 작업 범위
<!-- 해당되는 항목 체크 -->
- [ ] Front (Vue)
- [x] Back (Spring)
- [x] Infra

---

## ✅ 테스트 확인 (선택)
<!-- 확인한 항목 체크 -->

- [x] 정상 동작 확인
- [x] 콘솔 에러 없음
- [x] API 응답 정상
- [x] 예외 케이스 테스트

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, API 명세 변경 사항, DB 변경 사항 등 -->
`DELETE /api/seats/hold`